### PR TITLE
Update `SQLAlchemy` version specifier in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'faker>=13.3.0',
         'pandas>=1.4.0',
         'networkx>=2.7',
-        'SQLAlchemy>=1.4.31<2.0.0'
+        'SQLAlchemy>=1.4.31,<2.0.0'
     ],
     extras_require={
         'modin': ['modin[all]>=0.13.2']


### PR DESCRIPTION
I believe it should help to avoid the following deprecation: `DEPRECATION: fuzzydata 0.0.8 has a non-standard dependency specifier SQLAlchemy>=1.4.31<2.0.0. pip 24.0 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of fuzzydata or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063`