### PR TITLE
Update SQLAlchemy pin from >=1.4.31,<2.0.0 -> >=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas
 networkx
 pytest
 pytest-cov
-SQLAlchemy<2.0.0
+SQLAlchemy>=2.0.0
 modin[all]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'faker>=13.3.0',
         'pandas>=1.4.0',
         'networkx>=2.7',
-        'SQLAlchemy>=1.4.31,<2.0.0'
+        'SQLAlchemy>=2.0.0'
     ],
     extras_require={
         'modin': ['modin[all]>=0.13.2']


### PR DESCRIPTION
sqlalchemy 2.0.0 is the minimum supported version for pandas 2.2.0. I started to adopt a new version of pandas (https://github.com/modin-project/modin/pull/6907) and ran into dependency incompatibility.

Hi @suhailrehman, what do you think about updating sqlalchemy versions?

**Please note:** although I changed the pin, I did not manually test the changes.